### PR TITLE
フロント: 投稿一覧の表示を実装

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,23 +1,61 @@
-<script setup lang="ts">
-const nuxtApp = useNuxtApp()
-console.log('API baseURL:', nuxtApp.$api?.defaults?.baseURL)
-const health = ref<any>(null)
-const error = ref('')
+<template>
+  <main class="max-w-[720px] mx-auto p-4 space-y-4">
+    <header class="flex items-center justify-between">
+      <h1 class="text-xl font-bold">タイムライン</h1>
+      <NuxtLink to="/login" class="underline text-sm">ログイン</NuxtLink>
+    </header>
 
-onMounted(async () => {
-  try {
-    const res = await nuxtApp.$api.get('/health')
-    health.value = res.data
-  } catch (e: any) {
-    error.value = e?.message || String(e)
-  }
+    <!-- ローディング -->
+    <div v-if="pending">読み込み中...</div>
+
+    <!-- エラー -->
+    <div v-else-if="error" class="text-red-600">
+      取得に失敗しました: {{ (error as any).message ?? error }}
+    </div>
+
+    <!-- 一覧 -->
+    <ul v-else class="space-y-3">
+      <li v-for="post in posts" :key="post.id" class="border rounded p-3">
+        <div class="text-sm text-gray-500">
+          @{{ post.user?.username ?? 'unknown' }} ・ #{{ post.id }}
+        </div>
+        <p class="mt-1 whitespace-pre-wrap break-words">{{ post.content }}</p>
+        <div class="mt-2 text-sm text-gray-600">
+          💬 {{ post.comments_count }}　❤️ {{ post.likes_count }}
+        </div>
+      </li>
+    </ul>
+  </main>
+</template>
+
+<script setup lang="ts">
+type UserLite = { id: number; username: string }
+type PostItem = {
+  id: number
+  content: string
+  user?: UserLite
+  comments_count: number
+  likes_count: number
+}
+
+const { $api } = useNuxtApp()
+
+// /api/v1/posts は Laravel 側で paginate している想定
+// ここでは 1ページ目だけ表示
+const { data, pending, error } = await useAsyncData('posts:index', async () => {
+  const res = await $api.get('/posts')
+  return res.data
+})
+
+// Laravel paginate の戻りに合わせて items を取り出す
+const posts = computed<PostItem[]>(() => {
+  // res.data の形が { data: [...], current_page: 1, ... } 想定
+  // もしフラット配列だけ返しているなら data.value をそのまま返す
+  if (!data.value) return []
+  return Array.isArray(data.value.data) ? data.value.data : data.value
 })
 </script>
 
-<template>
-  <div style="padding:2rem">
-    <h1>Nuxt ⇔ Laravel Health</h1>
-    <p v-if="error">Error: {{ error }}</p>
-    <pre v-else>{{ health }}</pre>
-  </div>
-</template>
+<style scoped>
+/* 必要なら簡単なスタイルを足す */
+</style>


### PR DESCRIPTION
追加: pages/index.vue で /api/v1/posts を取得 → ユーザー名/本文/コメント数/いいね数を表示

追加: plugins/axios.ts（.env の NUXT_PUBLIC_API_BASE 使用）

動作確認: npm run dev で一覧が表示されること

依存: バックエンドの posts API