### PR TITLE
feat: 投稿の文字数制限を厳密化 & 投稿直後のUX改善

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -68,7 +68,8 @@ const onPosted = (post?: Post) => {
     // 直後に正規データで再同期（並びやcountの整合を取る）
     fetchPosts()
   } else {
-
+    // 念のため
+    fetchPosts()
   }
 }
 //削除処理


### PR DESCRIPTION
- Array.from による文字数カウントに統一
- VeeValidate スキーマに len-120 の厳密判定を追加
- meta.valid に連動して送信ボタンを制御
- 投稿後は楽観更新しつつ、整合のため即座に一覧を再取得