### PR TITLE
feat(frontend): 投稿詳細にコメント機能を実装

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -21,6 +21,10 @@
               💬 {{ p.comments_count ?? p.comments?.length ?? 0 }}
               ❤️ {{ p.likes_count ?? p.likes?.length ?? 0 }}
             </div>
+            <!-- コメントリンク -->
+            <NuxtLink :to="`/posts/${p.id}`" class="to-detail" aria-label="コメントへ">
+              💬 コメントする
+            </NuxtLink>
             <!-- いいねボタン-->
             <button class="like" :disabled="p._liking" @click="toggleLike(p)" aria-label="いいねをトグル" title="いいね">
               ❤️ いいね
@@ -142,4 +146,7 @@ onMounted(fetchPosts)
 .counts { margin-top: 6px; color: #666; font-size: 13px; }
 .danger { padding: 4px 8px; border-radius: 8px; background: #fee; border: 1px solid #f99; color: #900; }
 .danger:hover { background: #fdd; }
+.to-detail { margin-left: 8px; font-size: 13px; color: #06c; }
+.to-detail:hover { text-decoration: underline; }
 </style>
+

--- a/app/pages/posts/[id].vue
+++ b/app/pages/posts/[id].vue
@@ -1,3 +1,4 @@
+<!-- app/pages/posts/[id].vue -->
 <template>
   <main class="wrap">
     <section class="feed">
@@ -13,6 +14,20 @@
         </header>
         <p class="body">{{ post?.content }}</p>
 
+        <!-- ▼ コメント投稿フォーム -->
+        <form class="c-form" @submit.prevent="submitComment">
+          <textarea v-model="content" v-bind="contentAttrs" rows="3" name="content" placeholder="コメントを入力(最大120文字)"
+            maxlength="120"></textarea>
+          <div class="c-row">
+            <small class="hint">
+              {{ charCount }}/120
+              <span v-if="errors.content" class="error">（{{ errors.content }}）</span>
+              <span v-else-if="serverError" class="error">（{{ serverError }}）</span>
+            </small>
+            <button class="btn" type="submit" :disabled="isSubmitting || !meta.valid">コメントする</button>
+          </div>
+        </form>
+
         <h2 class="sub">コメント</h2>
         <ul class="list">
           <li v-for="c in comments" :key="c.id" class="item">
@@ -27,6 +42,10 @@
 </template>
 
 <script setup lang="ts">
+import { useRoute } from 'vue-router'           // ★ 追加
+import { useForm } from 'vee-validate'
+import * as yup from 'yup'
+
 type User = { id: number; username?: string }
 type Comment = { id: number; content: string; user?: User }
 type Post = { id: number; content: string; user?: User }
@@ -39,20 +58,86 @@ const comments = ref<Comment[]>([])
 const loading = ref(false)
 const error = ref<unknown>(null)
 
+/* ▼ コメントフォーム用 ▼ */
+const MAX = 120
+const graphemeLen = (s: string) => Array.from(s ?? '').length
+
+const schema = yup.object({
+  content: yup
+    .string()
+    .transform(v => (v ?? '').trim())
+    .required('必須です')
+    .test('len-120', '120文字以内', v => graphemeLen(v ?? '') <= MAX),
+})
+
+const {
+  defineField,
+  handleSubmit,
+  resetForm,
+  isSubmitting,
+  errors,
+  meta,
+  setFieldError,
+} = useForm({
+  validationSchema: schema,
+  validateOnInput: true,
+  initialValues: { content: '' },
+})
+
+const [content, contentAttrs] = defineField<string>('content')
+
+// 文字数は computed で一元管理（結合文字対応）
+const charCount = computed(() => graphemeLen(content.value || ''))
+const serverError = ref<string>('')
+
+const submitComment = handleSubmit(async (vals) => {
+  serverError.value = ''
+
+  const pid = Number(route.params.id)
+  // 楽観更新: 仮コメントを先頭に。負の一時IDで衝突回避
+  const optimisticId = -Date.now()
+  const optimistic: Comment = {
+    id: optimisticId,
+    content: vals.content.trim(),
+    user: { id: 1, username: 'you' },
+  }
+  comments.value = [optimistic, ...comments.value]
+
+  try {
+    const res = await $api.post(`/posts/${pid}/comments`, {
+      content: vals.content,
+      user_id: 1, // 認証導入前の暫定
+    })
+    // 成功 → 仮を確定値に置き換え
+    const idx = comments.value.findIndex(c => c.id === optimisticId)
+    if (idx !== -1) comments.value.splice(idx, 1, res.data)
+    resetForm()
+  } catch (err: any) {
+    // 422 などフォームエラー
+    const e = err?.response?.data
+    if (e?.errors?.content?.[0]) {
+      setFieldError('content', String(e.errors.content[0]))
+    } else {
+      serverError.value = e?.message || 'コメントの投稿に失敗しました'
+    }
+    // ロールバック
+    comments.value = comments.value.filter(c => c.id !== optimisticId)
+    console.error(err)
+  }
+})
+/* ▲ コメントフォーム用 ▲ */
+
 const fetchDetail = async () => {
   loading.value = true
   error.value = null
   try {
     const id = Number(route.params.id)
 
-    // ① 投稿本体（簡易: /posts 一覧から拾う実装でもOK。必要なら /posts/:id を後で追加）
-    // ここでは一覧の簡易APIが無い想定なので /posts を取って対象を探す or 省略
-    // まずはコメント一覧だけ出す方針にして post は最低限の表示にしておく
+    // 投稿本体（詳細 API が未実装のため仮表示）
     post.value = { id, content: '(本文は後で取得に差し替え)', user: { id: 0, username: 'unknown' } }
 
-    // ② コメント一覧
-    const res = await $api.get(`/posts/${id}/comments`)
-    // ページネーションで { data: [...] } の場合と、生配列の2パターンに対応
+    // コメント一覧
+    const res = await $api.get(`/posts/${id}/comments`, { params: { _t: Date.now() } })
     comments.value = Array.isArray(res.data?.data) ? res.data.data : res.data
   } catch (e) {
     error.value = e
@@ -65,15 +150,100 @@ onMounted(fetchDetail)
 </script>
 
 <style scoped>
-.wrap { max-width: 720px; margin: 0 auto; padding: 16px; }
-.feed { display: grid; gap: 12px; }
-.back { font-size: 13px; color: #06c; }
-.heading { font-weight: 700; font-size: 18px; }
-.sub { margin-top: 16px; font-weight: 700; font-size: 16px; }
-.err { color: #c00; }
-.post, .item { border: 1px solid #eee; border-radius: 8px; padding: 12px; }
-.meta { color: #666; font-size: 13px; }
-.body { margin-top: 4px; white-space: pre-wrap; word-break: break-word; }
-.list { display: grid; gap: 10px; margin-top: 8px; }
-.muted { color: #999; font-size: 13px; }
+.wrap {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.feed {
+  display: grid;
+  gap: 12px;
+}
+
+.back {
+  font-size: 13px;
+  color: #06c;
+}
+
+.heading {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.sub {
+  margin-top: 16px;
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.err {
+  color: #c00;
+}
+
+.post,
+.item {
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.meta {
+  color: #666;
+  font-size: 13px;
+}
+
+.body {
+  margin-top: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.list {
+  display: grid;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.muted {
+  color: #999;
+  font-size: 13px;
+}
+
+.c-form {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.c-form textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+}
+
+.c-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.btn {
+  padding: 6px 12px;
+  border-radius: 8px;
+}
+
+.btn[disabled] {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.hint {
+  color: #666;
+  font-size: 12px;
+}
+
+.error {
+  color: #c00;
+}
 </style>

--- a/app/pages/posts/[id].vue
+++ b/app/pages/posts/[id].vue
@@ -1,0 +1,79 @@
+<template>
+  <main class="wrap">
+    <section class="feed">
+      <NuxtLink to="/" class="back">← 戻る</NuxtLink>
+      <h1 class="heading">投稿の詳細 / コメント</h1>
+
+      <div v-if="loading">読み込み中...</div>
+      <div v-else-if="error" class="err">取得に失敗：{{ (error as any)?.message || error }}</div>
+
+      <article v-else class="post">
+        <header class="meta">
+          @{{ post?.user?.username ?? 'unknown' }} ・ #{{ post?.id }}
+        </header>
+        <p class="body">{{ post?.content }}</p>
+
+        <h2 class="sub">コメント</h2>
+        <ul class="list">
+          <li v-for="c in comments" :key="c.id" class="item">
+            <div class="meta">@{{ c.user?.username ?? 'unknown' }} ・ #{{ c.id }}</div>
+            <p class="body">{{ c.content }}</p>
+          </li>
+          <li v-if="comments.length === 0" class="muted">まだコメントはありません</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+type User = { id: number; username?: string }
+type Comment = { id: number; content: string; user?: User }
+type Post = { id: number; content: string; user?: User }
+
+const route = useRoute()
+const { $api } = useNuxtApp()
+
+const post = ref<Post | null>(null)
+const comments = ref<Comment[]>([])
+const loading = ref(false)
+const error = ref<unknown>(null)
+
+const fetchDetail = async () => {
+  loading.value = true
+  error.value = null
+  try {
+    const id = Number(route.params.id)
+
+    // ① 投稿本体（簡易: /posts 一覧から拾う実装でもOK。必要なら /posts/:id を後で追加）
+    // ここでは一覧の簡易APIが無い想定なので /posts を取って対象を探す or 省略
+    // まずはコメント一覧だけ出す方針にして post は最低限の表示にしておく
+    post.value = { id, content: '(本文は後で取得に差し替え)', user: { id: 0, username: 'unknown' } }
+
+    // ② コメント一覧
+    const res = await $api.get(`/posts/${id}/comments`)
+    // ページネーションで { data: [...] } の場合と、生配列の2パターンに対応
+    comments.value = Array.isArray(res.data?.data) ? res.data.data : res.data
+  } catch (e) {
+    error.value = e
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchDetail)
+</script>
+
+<style scoped>
+.wrap { max-width: 720px; margin: 0 auto; padding: 16px; }
+.feed { display: grid; gap: 12px; }
+.back { font-size: 13px; color: #06c; }
+.heading { font-weight: 700; font-size: 18px; }
+.sub { margin-top: 16px; font-weight: 700; font-size: 16px; }
+.err { color: #c00; }
+.post, .item { border: 1px solid #eee; border-radius: 8px; padding: 12px; }
+.meta { color: #666; font-size: 13px; }
+.body { margin-top: 4px; white-space: pre-wrap; word-break: break-word; }
+.list { display: grid; gap: 10px; margin-top: 8px; }
+.muted { color: #999; font-size: 13px; }
+</style>


### PR DESCRIPTION
## 概要
- 投稿詳細ページにコメント投稿機能を実装しました。
- 楽観的UI更新（送信直後に仮コメントを挿入 → サーバ応答で確定置換）
- 文字数カウントは結合文字対応（Array.from）で120文字制限に対応
- VeeValidate + Yup によるバリデーション（必須／120文字以内）
- サーバ側422やその他エラーのメッセージ表示を実装

## 変更点
- app/pages/posts/[id].vue
  - コメントフォーム、送信処理、一覧描画を実装
  - `useRoute` の明示的 import
  - `serverError` で一般エラーも表示
  - 楽観更新の置換を一時IDで安全に処理

## 動作確認
- `npm run dev` で起動
- `/posts/1` などにアクセスし、コメント投稿
- ネットワーク遮断や422(120文字超など)でメッセージ出力を確認

## 補足
- 将来的に認証導入時は `user_id: 1` の暫定値を削除し、ログインユーザーから取得に変更予定
