### PR TITLE
feat(フロント):Firebase認証と/me確認ボタンを追加

### DIFF
--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -25,6 +25,8 @@
       <span v-else>signed out</span>
     </p>
     <p v-if="err" class="text-red-600 text-sm mt-2">{{ err }}</p>
+    <button class="border p-2" @click="fetchMe">/me を呼ぶ</button>
+    <pre>{{ me }}</pre>
   </div>
 </template>
 
@@ -33,6 +35,8 @@ const email = ref('')
 const password = ref('')
 const err = ref<string>('')
 const { user, ready, login, register, logout } = useFirebaseAuth()
+const { $api } = useNuxtApp()
+const me = ref<any>(null)
 const onLogin = async () => {
   err.value = ''
   try { await login(email.value, password.value) }
@@ -44,4 +48,8 @@ const onRegister = async () => {
   catch (e: any) { err.value = e?.code || e?.message || String(e) }
 }
 const onLogout = async () => { await logout() }
+
+const fetchMe = async () => {
+  try { me.value = await $api('/me') } catch (e) { console.error(e) }
+}
 </script>


### PR DESCRIPTION
## 概要
Firebase 認証を導入し、取得した ID トークンでバックエンドの `GET /api/me` を呼べる確認 UI を追加。

## 変更内容
- 追加: `app/composables/useFirebaseAuth.ts`（`login` / `register` / `logout` / `getIdToken`）
- 追加: `app/plugins/api.client.ts`（`$api`：`Authorization: Bearer <idToken>` を自動付与）
- 追加: `app/pages/login.vue`（登録・ログイン・ログアウト + **「/me を呼ぶ」** ボタン）
- 設定: `nuxt.config.ts` に `srcDir: 'app'` と `runtimeConfig.public.apiBase` を明記
- 削除: 旧 `app/plugins/axios.ts`（競合回避）

## 動作確認
- `.env` 設定  
  - `NUXT_PUBLIC_API_BASE=http://localhost:8000/api`（※ `/v1` は付けない）  
  - Firebase Web SDK 各キーを設定
- `npm run dev` → `http://localhost:3000/login`
- Register → Login → **「/me を呼ぶ」** をクリック
- Network で確認  
  - Request URL: `http://localhost:8000/api/me`  
  - Request Headers: `Authorization: Bearer <token>`  
  - Response: `200` で `{ id, name, username, email, firebase_uid }`

## 影響範囲
- 認証周り（API 呼び出しの共通化）  
- 既存画面への影響なし（追加は `/login` のみ）

## 関連
- `GET /api/me`（バックエンドの認証確認用エンドポイント）

## チェックリスト
- [ ] `/api/me` が 200 を返す Network & 画面のスクショ添付  
- [ ] `.env.example` に必要キーを追記  
- [ ] デバッグ `console.log` を削除済み