### PR TITLE
feat(ui): 投稿フォームをサイドバーに統一し、画像アップロードとプレビューを追加

### DIFF
--- a/app/components/PostCard.vue
+++ b/app/components/PostCard.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { fileUrl } from '@/utils/fileUrl'
+defineProps<{ post: any }>()
+</script>
+
+<template>
+  <article>
+    <!-- 既存の本文・メタ情報など -->
+
+    <div v-if="post.images?.length" class="mt-2 grid grid-cols-2 gap-2">
+      <img v-for="img in post.images" :key="img.id" :src="fileUrl(img)" class="w-full h-48 object-cover rounded" alt="">
+    </div>
+  </article>
+</template>

--- a/app/components/PostComposer.vue
+++ b/app/components/PostComposer.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import { ref, computed, onBeforeUnmount } from 'vue'
+
+const { $api } = useNuxtApp()
+const emit = defineEmits<{ (e: 'posted', post?: any): void }>()
+
+const MAX_FILES = 4
+const MAX_SIZE_MB = 15                  // ★ クライアント側の上限(表示/事前チェック用)
+const MAX_SIZE = MAX_SIZE_MB * 1024 * 1024
+const ACCEPTS = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
+
+const content = ref('')
+const files = ref<File[]>([])
+const previews = ref<string[]>([])
+const posting = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null) // ★ 追加
+
+const canSubmit = computed(() => content.value.trim().length > 0 || files.value.length > 0)
+
+const syncNativeInput = () => { // ★ input の表示と選択状態を同期
+  const el = fileInput.value
+  if (!el) return
+  try {
+    const dt = new DataTransfer()
+    for (const f of files.value) dt.items.add(f)
+    // @ts-ignore
+    el.files = dt.files
+    if (files.value.length === 0) el.value = ''
+  } catch {
+    // Safari等のfallback
+    el.value = ''
+  }
+}
+
+const addFiles = (list: FileList | null) => {
+  if (!list) return
+  const next = [...files.value]
+  for (const f of Array.from(list)) {
+    if (!ACCEPTS.includes(f.type)) { alert('対応外の画像形式です'); continue }
+    if (f.size > MAX_SIZE) { alert(`${MAX_SIZE_MB}MBを超えています`); continue }
+    if (next.length >= MAX_FILES) { alert('画像は最大4枚までです'); break }
+    next.push(f)
+  }
+  files.value = next
+  rebuildPreviews()
+  syncNativeInput() // ★
+}
+
+const removeAt = (i: number) => {
+  files.value.splice(i, 1)
+  rebuildPreviews()
+  syncNativeInput() // ★
+}
+
+const rebuildPreviews = () => {
+  previews.value.forEach(u => URL.revokeObjectURL(u))
+  previews.value = files.value.map(f => URL.createObjectURL(f))
+}
+onBeforeUnmount(() => previews.value.forEach(u => URL.revokeObjectURL(u)))
+
+const submit = async () => {
+  if (!canSubmit.value) { alert('本文または画像のいずれかは必須です'); return }
+  posting.value = true
+  try {
+    const form = new FormData()
+    form.append('content', content.value)
+    for (const f of files.value) form.append('images[]', f)
+
+    const res = await $api.post('/posts', form) // pluginは {data} 返却
+    const createdPost = res?.data ?? null
+
+    // リセット
+    content.value = ''
+    files.value = []
+    rebuildPreviews()
+    syncNativeInput() // ★ input表示も空に
+
+    emit('posted', createdPost)
+  } catch (e: any) {
+    console.error(e)
+    alert(e?.response?.data?.message ?? '送信に失敗しました')
+  } finally {
+    posting.value = false
+  }
+}
+</script>
+
+<template>
+  <form @submit.prevent="submit" class="space-y-3">
+    <textarea v-model="content" maxlength="120" placeholder="いまどうしてる？（120文字まで）"
+      class="w-full border rounded p-2"></textarea>
+
+    <div>
+      <input ref="fileInput" type="file" multiple accept=".jpg,.jpeg,.png,.webp,.gif"
+        @change="addFiles(($event.target as HTMLInputElement).files)" />
+      <p class="text-sm text-gray-500">
+        画像は最大4枚、各{{ MAX_SIZE_MB }}MBまで（jpg/png/webp/gif）
+      </p>
+    </div>
+
+    <client-only>
+      <div v-if="previews.length" class="previewGrid">
+        <div v-for="(src, i) in previews" :key="i" class="thumb">
+          <img :src="src" alt="">
+          <button type="button" class="del" @click="removeAt(i)">削除</button>
+        </div>
+      </div>
+    </client-only>
+
+    <button :disabled="!canSubmit || posting" class="submitBtn">
+      {{ posting ? '投稿中…' : 'シェアする' }}
+    </button>
+  </form>
+</template>
+
+<style scoped>
+.previewGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  margin-top: 8px
+}
+
+.thumb {
+  position: relative
+}
+
+.thumb img {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 8px;
+  display: block
+}
+
+.del {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 12px;
+  padding: 2px 6px;
+  color: #fff;
+  background: rgba(0, 0, 0, .6);
+  border-radius: 6px
+}
+
+.submitBtn {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 8px;
+  color: #fff;
+  background: #2563eb
+}
+
+.submitBtn[disabled] {
+  opacity: .5;
+  cursor: not-allowed
+}
+</style>

--- a/app/components/SideNav.vue
+++ b/app/components/SideNav.vue
@@ -1,98 +1,31 @@
 <template>
   <aside class="side">
     <h2 class="title">シェア</h2>
-
-    <form @submit.prevent="onSubmit" class="form">
-      <textarea
-        v-model="content"
-        v-bind="contentAttrs"
-        name="content"
-        rows="4"
-        placeholder="いまどうしてる？"
-        class="textarea"
-        maxlength="120"
-      ></textarea>
-      <div class="row">
-        <small class="hint">
-          {{ Array.from(content || '').length }}/120
-          <span v-if="errors.content" class="error">（{{ errors.content }}）</span>
-        </small>
-        <small v-if="serverError" class="error">{{ serverError }}</small>
-
-        <!-- 送信中のみ無効化。バリデーションは handleSubmit が担当 -->
-        <button type="submit" :disabled="isSubmitting || !meta.valid" class="btn">
-          シェアする
-        </button>
-      </div>
-    </form>
+    <!-- PostComposer を内包し、posted をそのまま親へバブリング -->
+    <PostComposer @posted="p => emit('posted', p)" />
   </aside>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useForm } from 'vee-validate'
-import * as yup from 'yup'
-
-const emit = defineEmits<{ (e: 'posted', post: any): void }>()
-
-const MAX = 120
-const graphemeLen = (s: string) => Array.from(s).length
-
-// スキーマ（トリム + 絵文字等も1文字としてカウント）
-const schema = yup.object({
-  content: yup
-    .string()
-    .transform(v => (v ?? '').trim())
-    .required('必須です')
-    .test('len-120', '120文字以内', (v) => graphemeLen(v ?? '') <= MAX)
-})
-
-// defineField で v-model を安全に
-const { defineField, errors, handleSubmit, resetForm, isSubmitting, meta, setFieldError } = useForm({
-  validationSchema: schema,
-  validateOnInput: true,
-  initialValues: { content: '' }
-})
-const [content, contentAttrs] = defineField<string>('content')
-
-// サーバー由来の一般エラー表示用
-const serverError = ref<string>('')
-
-const onSubmit = handleSubmit(async (vals) => {
-  const { $api } = useNuxtApp()
-  try {
-    // content で入力→送信は body に寄せる(user_idは不要)
-    const res = await $api.post('/posts', { body: vals.content})
-    resetForm()
-    serverError.value = ''
-    emit('posted', res.data) // 親へ通知（タイムライン即時反映）
-  } catch (err: any) {
-    // 422 のフィールドエラー → VeeValidate に反映
-    const e = err?.response?.data
-    const fe = e?.errors
-    // サーバーはbodyをキーに返してくるのでcontentに写す
-    if (fe?.body?.length) {
-      setFieldError('content', String(fe.body[0]))
-    } else if (fe?.content?.length) {
-      //念のため後方互換
-      setFieldError('content', String(fe.content[0]))
-    } else {
-      serverError.value = e?.message || '送信に失敗しました'
-    }
-    // 画面上部に赤エラーが欲しければ throw を残す。不要なら削除可。
-    throw err
-  }
-})
+import PostComposer from '~/components/PostComposer.vue'
+const emit = defineEmits<{ (e: 'posted', post?: any): void }>()
 </script>
 
 <style scoped>
-.side { max-width: 260px; width: 100%; }
-.title { font-weight: 700; margin-bottom: 8px; }
-.form { display: grid; gap: 8px; }
-.textarea { width: 100%; box-sizing: border-box; resize: vertical; }
-.row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
-.btn { padding: 6px 12px; border-radius: 8px; }
-.btn[disabled] { opacity: .5; cursor: not-allowed; }
-.hint { color: #666; }
-.error { color: #c00; }
+.side {
+  max-width: 260px;
+  width: 100%;
+}
+
+.title {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+/* 内側のフォーム要素をサイド幅に収める */
+:deep(textarea),
+:deep(input[type="file"]),
+:deep(button) {
+  width: 100%;
+}
 </style>

--- a/app/utils/fileUrl.ts
+++ b/app/utils/fileUrl.ts
@@ -1,0 +1,6 @@
+export const fileUrl = (img: { url?: string; path?: string }) => {
+  if (img?.url) return img.url;
+  const { public: cfg } = useRuntimeConfig();
+  const origin = new URL(cfg.apiBase).origin; // 例: http://127.0.0.1:8000
+  return new URL(`/storage/${img.path}`, origin).toString();
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,4 @@
-
+// nuxt.config.ts
 export default defineNuxtConfig({
   srcDir: 'app',
   pages: true,
@@ -7,11 +7,21 @@ export default defineNuxtConfig({
   modules: ['@pinia/nuxt'],
   runtimeConfig: {
     public: {
+      // 既存: Firebase
       firebaseApiKey: process.env.NUXT_PUBLIC_FIREBASE_API_KEY,
       firebaseAuthDomain: process.env.NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
       firebaseProjectId: process.env.NUXT_PUBLIC_FIREBASE_PROJECT_ID,
       firebaseStorageBucket: process.env.NUXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-      apiBase: process.env.NUXT_PUBLIC_API_BASE,
+
+      // 既存: API ベース（※末尾スラッシュなしが安全）
+      // 例) http://127.0.0.1:8000/api/v1
+      apiBase: process.env.NUXT_PUBLIC_API_BASE
+        ?? 'http://127.0.0.1:8000/api/v1',
+
+      // 追加: 画像の /storage 用にオリジンだけ欲しいので用意
+      // 例) http://127.0.0.1:8000
+      apiBaseOrigin: process.env.NUXT_PUBLIC_API_BASE_ORIGIN
+        ?? 'http://127.0.0.1:8000',
     },
   },
 })


### PR DESCRIPTION
## 目的
- 投稿フォームをサイドバーに一本化し、画像投稿/UI（プレビュー/削除）を追加
- タイムラインで画像クリック → ライトボックス拡大表示

## 変更点
- SideNav.vue: PostComposer を内包、@posted を index にバブリング
- PostComposer.vue:
  - FormData 送信（$api.post）
  - 画像プレビュー、最大4枚/各15MB（文言は env と整合）
  - サムネ削除時に <input type="file"> の表示名も同期
- index.vue:
  - 画像グリッド表示
  - ライトボックス（クリック/ESC/←→）
- utils/fileUrl.ts: apiBase からオリジン抽出

## 動作確認
- [x] テキストのみ / 画像のみ / 両方で投稿成功
- [x] 5枚目でクライアント警告 + サーバ422
- [x] TL で画像表示 & クリック拡大
- [x] 送信直後にTL先頭へ挿入 → 再取得

## 依存
- Backend PR: #<backend-pr-number> に依存（画像API）
